### PR TITLE
Fixed bug with the wrapped observer not being removed.

### DIFF
--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -34,16 +34,18 @@ class LiveEvent<T> : MediatorLiveData<T>() {
 
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
+        var wrapper = observer
         if (!observers.remove(observer)) {
             val iterator = observers.iterator()
             while (iterator.hasNext()) {
-                if (iterator.next().observer == observer) {
+                wrapper = iterator.next()
+                if (wrapper.observer == observer) {
                     iterator.remove()
                     break
                 }
             }
         }
-        super.removeObserver(observer)
+        super.removeObserver(wrapper)
     }
 
     @MainThread

--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -35,7 +35,7 @@ class LiveEvent<T> : MediatorLiveData<T>() {
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
         var wrapper = observer
-        if (!observers.remove(observer)) {
+        if (!observers.remove(wrapper)) {
             val iterator = observers.iterator()
             while (iterator.hasNext()) {
                 wrapper = iterator.next()


### PR DESCRIPTION
If the `removeObserver` method is called by passing the original `Observer`, the `ObserverWrapper` is not passed to the `super.removeObserver` after it is removed from the `observers` `ArraySet`