### PR TITLE
Fixed bug with the wrapped observer not being removed. 

### DIFF
--- a/build-system/dependency.gradle
+++ b/build-system/dependency.gradle
@@ -22,7 +22,7 @@ ext {
 
     groupId = 'com.github.hadilq.liveevent'
     artifactId = 'liveevent'
-    libVersion = '1.0.0'
+    libVersion = '1.0.1'
 
     androidx_lib_version = '1.0.0'
     constraint_layout_version = '1.1.3'

--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -34,18 +34,19 @@ class LiveEvent<T> : MediatorLiveData<T>() {
 
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
-        var wrapper = observer
-        if (!observers.remove(wrapper)) {
-            val iterator = observers.iterator()
-            while (iterator.hasNext()) {
-                wrapper = iterator.next()
-                if (wrapper.observer == observer) {
-                    iterator.remove()
-                    break
-                }
+        if (observers.remove(observer)) {
+            super.removeObserver(observer)
+            return
+        }
+        val iterator = observers.iterator()
+        while (iterator.hasNext()) {
+            val wrapper = iterator.next()
+            if (wrapper.observer == observer) {
+                iterator.remove()
+                super.removeObserver(wrapper)
+                break
             }
         }
-        super.removeObserver(wrapper)
     }
 
     @MainThread

--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -34,16 +34,18 @@ class LiveEvent<T> : MediatorLiveData<T>() {
 
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
+        var wrapper = observer
         if (!observers.remove(observer)) {
             val iterator = observers.iterator()
             while (iterator.hasNext()) {
-                if (iterator.next().observer == observer) {
+                wrapper = iterator.next()
+                if (wrapper.observer == observer) {
                     iterator.remove()
                     break
                 }
             }
         }
-        super.removeObserver(observer)
+        super.removeObserver(wrapper)
     }
 
     @MainThread

--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -35,7 +35,7 @@ class LiveEvent<T> : MediatorLiveData<T>() {
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
         var wrapper = observer
-        if (!observers.remove(observer)) {
+        if (!observers.remove(wrapper)) {
             val iterator = observers.iterator()
             while (iterator.hasNext()) {
                 wrapper = iterator.next()


### PR DESCRIPTION
If the `removeObserver` method is called by passing the original `Observer`, the `ObserverWrapper` is not passed to the `super.removeObserver` after it is removed from the `observers` `ArraySet`.

For more details look at https://github.com/hadilq/LiveEvent/pull/5