### PR TITLE
Up minSdk to match androidx.lifecycle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
     compileSdkVersion(Versions.compileSdkVersion)
     defaultConfig {
         applicationId = "com.hadilq.liveevent.sample"
-        minSdkVersion(14)
+        minSdkVersion(Versions.minSdkVersion)
         targetSdkVersion(Versions.targetSdkVersion)
         versionCode = 1
         versionName = "1.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
     const val compileSdkVersion = 28
     const val targetSdkVersion = 28
-    const val minSdkVersion = 9
+    const val minSdkVersion = 14
 
     const val kotlin_version = "1.3.11"
     const val dokka_version = "0.9.16"


### PR DESCRIPTION
I found that tests would not run due to the `androidx.lifecycle` minSdk being 14. I upped this library's minSdk to match.