### PR TITLE
Add support for a pending event to be observed immediately

### DIFF
--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -45,7 +45,7 @@ class LiveEvent<T> : MediatorLiveData<T>() {
 
     @MainThread
     override fun removeObserver(observer: Observer<in T>) {
-        if (observers.remove<Observer<out Any?>?>(observer)) {
+        if (observers.remove(observer)) {
             super.removeObserver(observer)
             return
         }
@@ -64,11 +64,11 @@ class LiveEvent<T> : MediatorLiveData<T>() {
     override fun setValue(t: T?) {
         if (observers.isEmpty()) {
             // if there are no observers mark a pending flag so new observers will pick up the event
-            pending.set(true)
+            pending.set(true) 
         } else {
-            // if there are some, then the existing observers consume the data and new ones have to
+            // if there are some, then the existing observers consume the data and new ones have to 
             // wait for the next setValue
-            pending.set(false)
+            pending.set(false) 
             observers.forEach { it.newValue() }
         }
 

--- a/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
+++ b/lib/src/main/java/com/hadilq/liveevent/LiveEvent.kt
@@ -20,6 +20,7 @@ import androidx.collection.ArraySet
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Observer
+import java.util.concurrent.atomic.AtomicBoolean
 
 class LiveEvent<T> : MediatorLiveData<T>() {
 
@@ -38,7 +39,7 @@ class LiveEvent<T> : MediatorLiveData<T>() {
 
     @MainThread
     override fun observeForever(observer: Observer<in T>) {
-        val wrapper = ObserverWrapper(observer)
+        val wrapper = ObserverWrapper(observer, pending.getAndSet(false))
         observers.add(wrapper)
         super.observeForever(wrapper)
     }
@@ -75,7 +76,7 @@ class LiveEvent<T> : MediatorLiveData<T>() {
         super.setValue(t)
     }
 
-    private class ObserverWrapper<T>(val observer: Observer<T>, initialPending: Boolean = false) : Observer<T> {
+    private class ObserverWrapper<T>(val observer: Observer<T>, initialPending: Boolean) : Observer<T> {
 
         private var pending = initialPending
 

--- a/lib/src/test/java/com/hadilq/liveevent/LiveEventTest.kt
+++ b/lib/src/test/java/com/hadilq/liveevent/LiveEventTest.kt
@@ -439,4 +439,20 @@ class LiveEventTest {
         verify(observer, times(1)).onChanged(event)
         verify(observer1, times(1)).onChanged(event)
     }
+    
+    @Test
+    fun `observe pending event`() {
+        // Given
+        owner.start()
+        val event = "event"
+        val lateObserver = mock<Observer<String>>()
+        
+        liveEvent.value = event
+        
+        // When
+        liveEvent.observe(owner, lateObserver)
+        
+        // Then
+        verify(lateObserver, times(1)).onChanged(event)
+    }
 }

--- a/lib/src/test/java/com/hadilq/liveevent/LiveEventTest.kt
+++ b/lib/src/test/java/com/hadilq/liveevent/LiveEventTest.kt
@@ -455,4 +455,33 @@ class LiveEventTest {
         // Then
         verify(lateObserver, times(1)).onChanged(event)
     }
+
+    @Test
+    fun `observe pending event just once`() {
+        // Given
+        owner.create()
+        owner.start()
+        owner.resume()
+        val event = "event"
+        val lateObserver = mock<Observer<String>>()
+
+        liveEvent.value = event
+
+        // When
+        liveEvent.observe(owner, lateObserver)
+        owner.pause() // simulate a configuration change
+        owner.stop()
+        owner.destroy()
+
+        val newOwner = TestLifecycleOwner()
+        val newObserver = mock<Observer<String>>()
+        newOwner.create()
+        newOwner.start()
+        newOwner.resume()
+        liveEvent.observe(newOwner, newObserver)
+
+        // Then
+        verify(lateObserver, times(1)).onChanged(event)
+        verify(newObserver, never()).onChanged(event)
+    }
 }


### PR DESCRIPTION
For your consideration...

When a `LiveEvent` has a value set but there are no observers the current value is simply not observed when an observer is added.  Observers will only see new values as they get set.  This is contrary to how `LiveData` behaves where a previously set value will be immediately observed by an observer. 

This can happen if, for example, a `ViewModel` sets a `LiveEvent` value during initialization and observers do not start observing until afterwards, say in `onResume`.

I feel `LiveEvent` should behave as similarly as possible to `LiveData` but with the only restriction of only emitting the value once for the current set of observers.